### PR TITLE
Fix typo on line 30 from 54 to 55

### DIFF
--- a/src/html-template03a.js
+++ b/src/html-template03a.js
@@ -27,7 +27,7 @@ const htmlTemplate = function(config) {
               ${pubAddr.slice(12, 24)}<br />
               ${pubAddr.slice(24, 36)}<br />
               ${pubAddr.slice(36, 48)}<br />
-              ${pubAddr.slice(48, 54)}<br />
+              ${pubAddr.slice(48, 55)}<br />
               SN# ${generateSN(rnd, i)}
 
             </p>


### PR DESCRIPTION
The last character on the slp address was not shown because the pubAddr.slice(48, 54) needed to be pubAddr.slice(48, 55) instead.